### PR TITLE
Correct small typo

### DIFF
--- a/pyrevolt/structs/channels.py
+++ b/pyrevolt/structs/channels.py
@@ -440,7 +440,7 @@ class Message:
             await self.update(result)
 
     async def Delete(self) -> None:
-        if self.author is self.sesison.self:
+        if self.author is self.sessison.self:
             await self.session.Request(Method.DELETE, f"/channels/{self.channel.channelID}/messages/{self.messageID}")
         else:
             if self.channel.type == ChannelType.SavedMessages | ChannelType.DirectMessage | ChannelType.Group:

--- a/pyrevolt/structs/channels.py
+++ b/pyrevolt/structs/channels.py
@@ -440,7 +440,7 @@ class Message:
             await self.update(result)
 
     async def Delete(self) -> None:
-        if self.author is self.sessison.self:
+        if self.author is self.session.self:
             await self.session.Request(Method.DELETE, f"/channels/{self.channel.channelID}/messages/{self.messageID}")
         else:
             if self.channel.type == ChannelType.SavedMessages | ChannelType.DirectMessage | ChannelType.Group:


### PR DESCRIPTION
Apologies for the inconvenience, but I noticed a minor typo in channel.py at lines 443 and 456, which I have corrected. The issue was encountered while utilizing your library.

The correction changes `sesison` to `session`.